### PR TITLE
Name cert files after application instead of hostname

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,5 +6,5 @@ laravel_rotate_nginx_log: true
 laravel_rotate_nginx_log_retention: 30
 
 laravel_https_enabled: false
-laravel_https_cert_path: '/etc/ssl/{{ server_name }}.crt'
-laravel_https_key_path: '/etc/ssl/{{ server_name }}.key'
+laravel_https_cert_path: '/etc/ssl/{{ application_name }}.crt'
+laravel_https_key_path: '/etc/ssl/{{ application_name }}.key'


### PR DESCRIPTION
## Summary of changes

Use application_name instead of server_name for the name of cert files, because server_name is not required for Vagrant boxes.

## How to Test

Use this in requirements file and provision a Vagrant box:

```yaml
- name: juwai.laravel
  scm: git
  src: git@github.com:tjoelsson/ansible-role-laravel.git
  version: 867cf1a
```