### PR TITLE
Use Laravel Ansible role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ laravel_https_key_path: '/etc/ssl/{{ laravel_application_name }}.key'
 laravel_https_redirect: false
 
 laravel_nginx_global_config: ''
+nginx_access_log_tag: 'main'
 
 laravel_nginx_extra_config: ''
 laravel_nginx_port: '{{ nginx_port | default(80) }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ laravel_https_enabled: false
 laravel_https_key_path: '/etc/ssl/{{ laravel_application_name }}.key'
 laravel_https_redirect: false
 
+laravel_nginx_global_config: ''
+
 laravel_nginx_extra_config: ''
 laravel_nginx_port: '{{ nginx_port | default(80) }}'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ laravel_https_key_path: '/etc/ssl/{{ laravel_application_name }}.key'
 laravel_https_redirect: false
 
 laravel_nginx_global_config: ''
-nginx_access_log_tag: 'main'
+laravel_nginx_access_log_format: 'main'
 
 laravel_nginx_extra_config: ''
 laravel_nginx_port: '{{ nginx_port | default(80) }}'

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,7 +9,7 @@ server {
         set $vhost 'current';
     }
     root {{ laravel_www_dir }}/{{ laravel_stage }}/{{ laravel_application_name }}/$vhost/public;
-    access_log /var/log/nginx/{{ laravel_application_name }}/$vhost-access.log {{ nginx_access_log_tag }};
+    access_log /var/log/nginx/{{ laravel_application_name }}/$vhost-access.log {{ laravel_nginx_access_log_format }};
     error_log /var/log/nginx/{{ laravel_application_name }}/error.log;
 
     {% if laravel_https_enabled -%}
@@ -23,7 +23,7 @@ server {
     server_name {{ laravel_server_name }};
 
     root {{ laravel_www_dir }}/{{ laravel_stage }}/{{ laravel_application_name }}/current/public;
-    access_log /var/log/nginx/{{ laravel_application_name }}/access.log {{ nginx_access_log_tag }};
+    access_log /var/log/nginx/{{ laravel_application_name }}/access.log {{ laravel_nginx_access_log_format }};
     error_log /var/log/nginx/{{ laravel_application_name }}/error.log;
 
     {% if laravel_https_enabled -%}
@@ -35,7 +35,7 @@ server {
     {% else %}
     listen {{ laravel_nginx_port }};
     root /vagrant/public;
-    access_log /var/log/nginx/{{ laravel_application_name }}/access.log {{ nginx_access_log_tag }};
+    access_log /var/log/nginx/{{ laravel_application_name }}/access.log {{ laravel_nginx_access_log_format }};
     error_log /var/log/nginx/{{ laravel_application_name }}/error.log;
 
     # Because of a bug in VirtualBox

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,4 +1,6 @@
 #jinja2: lstrip_blocks: True
+{{ laravel_nginx_global_config }}
+
 server {
     {% if laravel_env == 'staging' %}
     listen {{ laravel_nginx_port }};

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,7 +9,7 @@ server {
         set $vhost 'current';
     }
     root {{ laravel_www_dir }}/{{ laravel_stage }}/{{ laravel_application_name }}/$vhost/public;
-    access_log /var/log/nginx/{{ laravel_application_name }}/$vhost-access.log main;
+    access_log /var/log/nginx/{{ laravel_application_name }}/$vhost-access.log {{ nginx_access_log_tag }};
     error_log /var/log/nginx/{{ laravel_application_name }}/error.log;
 
     {% if laravel_https_enabled -%}
@@ -23,7 +23,7 @@ server {
     server_name {{ laravel_server_name }};
 
     root {{ laravel_www_dir }}/{{ laravel_stage }}/{{ laravel_application_name }}/current/public;
-    access_log /var/log/nginx/{{ laravel_application_name }}/access.log main;
+    access_log /var/log/nginx/{{ laravel_application_name }}/access.log {{ nginx_access_log_tag }};
     error_log /var/log/nginx/{{ laravel_application_name }}/error.log;
 
     {% if laravel_https_enabled -%}
@@ -35,7 +35,7 @@ server {
     {% else %}
     listen {{ laravel_nginx_port }};
     root /vagrant/public;
-    access_log /var/log/nginx/{{ laravel_application_name }}/access.log main;
+    access_log /var/log/nginx/{{ laravel_application_name }}/access.log {{ nginx_access_log_tag }};
     error_log /var/log/nginx/{{ laravel_application_name }}/error.log;
 
     # Because of a bug in VirtualBox


### PR DESCRIPTION
** Story**

## Summary of changes

Add a global setting holder in the front of configuration file.

## How to Test

1. Add juwai.laravel to playbook.yml

2.Specify the download url in .provisioning/requirement.yml as follow:
```
- name: juwai.laravel
  src: git@github.com:BarryPaneer/ansible-role-laravel.git
  scm: git
  version: PLAT-206
```

3. Then define a var 'laravel_nginx_global_config'

4. Run the playbook, we would see that the content which defined on 'laravel_nginx_global_config' has been write to nginx configuration file.



/fyi: @tjoelsson , @mark-juwai : Please review.

/cc: @zhangjustin : Need your input regarding _concern_.