### PR TITLE
Add option laravel_https_redirect_by_x_forwarded_proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Redirect site from http to https
 
 Default is `false`
 
+### laravel_https_redirect_by_x_forwarded_proto
+
+Redirect site from http to https if http_x_forwarded_proto is http
+
+Default is `false`
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ laravel_https_cert_path: '/etc/ssl/{{ laravel_application_name }}.crt'
 laravel_https_enabled: false
 laravel_https_key_path: '/etc/ssl/{{ laravel_application_name }}.key'
 laravel_https_redirect: false
+laravel_https_redirect_by_x_forwarded_proto: false
 
 laravel_nginx_global_config: ''
 laravel_nginx_access_log_format: 'main'

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -18,6 +18,12 @@ server {
     real_ip_recursive on;
     {%- endif %}
 
+    {% if laravel_https_redirect_by_x_forwarded_proto %}
+    if ($http_x_forwarded_proto = 'http') {
+        return 301 https://$host$request_uri;
+    }
+    {%- endif %}
+
     {% if laravel_https_enabled -%}
     ssl                         on;
     ssl_certificate             {{ laravel_https_cert_path }};
@@ -36,6 +42,12 @@ server {
     set_real_ip_from 0.0.0.0/0;
     real_ip_header X-Forwarded-For;
     real_ip_recursive on;
+    {%- endif %}
+
+    {% if laravel_https_redirect_by_x_forwarded_proto %}
+    if ($http_x_forwarded_proto = 'http') {
+        return 301 https://$host$request_uri;
+    }
     {%- endif %}
 
     {% if laravel_https_enabled -%}


### PR DESCRIPTION
## Summary of changes

- _Add option laravel_https_redirect_by_x_forwarded_proto, so that we can redirect site from http to https if http_x_forwarded_proto is http_

## How to Test

- Test with a project
