### PR TITLE
Remove _url parameter

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -69,10 +69,8 @@ server {
 
     index index.php index.html index.htm;
 
-    try_files $uri $uri/ @rewrite;
-
-    location @rewrite {
-        rewrite ^(.*)$ /index.php?_url=/$1;
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
     }
 
     location ~ \.php {


### PR DESCRIPTION
## Summary of changes

Update the Nginx configuration template to be closer to Laravel's documentation. This will avoid having the _url parameter show up in bug tracking software (i.e. Bugsnag).

## How to Test

Use this to provision an application server. Make sure all pages still work as before.

/fyi @mark-juwai 