### PR TITLE
Fix log rotation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     state: directory
     owner: 'nginx'
     group: 'nginx'
-    mode: 0775
+    mode: 0755
 
 - name: Rotation for project nginx log file
   logrotate:


### PR DESCRIPTION
## Summary of changes

It seems newer versions of logrotate will complain if the log directory is writable by group. See this error when running logrotate:

```
error: skipping "/var/log/nginx/app/access.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```

I don't think there's any reason to keep it writable by group.

## How to Test

Run with playbook.