### PR TITLE
Fix Nginx reopen logs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
       - 'create 0644 nginx nginx'
       - 'sharedscripts'
     scripts:
-      postrotate: '/etc/init.d/nginx reopen_logs'
+      postrotate: 'nginx -s reopen'
   when: laravel_rotate_nginx_log
 
 - name: Ensure storage folders present


### PR DESCRIPTION
## Summary of changes

The init script is not available in Amazon Linux 2. Need to use a different command to trigger reopening log files.

## How to Test

Run with playbook